### PR TITLE
fix: Only close output midi port if an underlying client exists

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -44,7 +44,10 @@ NodeMidiOutput::NodeMidiOutput(const Napi::CallbackInfo &info) : Napi::ObjectWra
 
 NodeMidiOutput::~NodeMidiOutput()
 {
-    handle->closePort();
+    if (handle)
+    {
+        handle->closePort();
+    }
 }
 
 Napi::Value NodeMidiOutput::GetPortCount(const Napi::CallbackInfo &info)


### PR DESCRIPTION
If the underlying `RtMidiOut` client could not be successfully created in the constructor `handle` will be set to a nullptr.

Before this patch the `closePort` method would be called on a null value resulting in a segmentation fault that crashes the whole node.js process in which the library is used.

The input class already has this check implemented, it is only missing in the output class.
