### PR TITLE
fix: change imports of EventEmitter in type def

### DIFF
--- a/midi.d.ts
+++ b/midi.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 
-import * as Stream from 'stream';
-import * as EventEmitter from 'events';
+import { Stream } from 'stream';
+import { EventEmitter } from 'events';
 
 /**
  * An array of numbers corresponding to the MIDI bytes: [status, data1, data2].


### PR DESCRIPTION
When trying to use node-midi with Typescript, i encountered this error:

```
release/app/node_modules/@julusian/midi/midi.d.ts:13:28 - error TS2507: Type 'typeof EventEmitter' is not a constructor function type.

13 export class Input extends EventEmitter {
                              ~~~~~~~~~~~~

Found 1 error in release/app/node_modules/@julusian/midi/midi.d.ts:13
```

After some search, i found out imports in type def file are not compatible with latest node types.
I am using @types/node v18.16.0.

Edit: not prio, i added `skipLibCheck` in my tsconfig, i originally thought node-midi was the reason why my tests failed, but in fact, i have no idea why, and it's not related to this package