### PR TITLE
feat: Add openPortByName methods for input and output ports

### DIFF
--- a/midi.d.ts
+++ b/midi.d.ts
@@ -32,6 +32,8 @@ export class Input extends EventEmitter {
     ignoreTypes(sysex: boolean, timing: boolean, activeSensing: boolean): void;
     /** Open the specified input port */
     openPort(port: number): void;
+    /** Open the specified input port */
+    openPortByName(name: string): void;
     /**
      * Instead of opening a connection to an existing MIDI device, on Mac OS X
      * and Linux with ALSA you can create a virtual device that other software
@@ -64,6 +66,8 @@ export class Output {
     isPortOpen(): boolean
     /** Open the specified output port */
     openPort(port: number): void;
+    /** Open the specified output port */
+    openPortByName(name: string): void;
     /**
      * Instead of opening a connection to an existing MIDI device, on Mac OS X
      * and Linux with ALSA you can create a virtual device that other software

--- a/midi.js
+++ b/midi.js
@@ -48,6 +48,14 @@ class Input extends EventEmitter {
   openPort(port) {
     return this.input.openPort(port)
   }
+  openPortByName(name) {
+    for(let port=0; port<this.input.getPortCount(); ++port) {
+      if (name === this.input.getPortName(port)) {
+        return this.input.openPort(port);
+      }
+    }
+    return undefined;
+  }
   openVirtualPort(port) {
     return this.input.openVirtualPort(port)
   }
@@ -78,6 +86,14 @@ class Output {
   }
   openPort(port) {
     return this.output.openPort(port)
+  }
+  openPortByName(name) {
+    for(let port=0; port<this.output.getPortCount(); ++port) {
+      if (name === this.output.getPortName(port)) {
+        return this.output.openPort(port);
+      }
+    }
+    return undefined;
   }
   openVirtualPort(port) {
     return this.output.openVirtualPort(port)


### PR DESCRIPTION
Provide a name-oriented way to open ports, rather than an index, since the MIDI index is want to change.
